### PR TITLE
fixed invalid json in rotz.json file preventing scoop install rotz

### DIFF
--- a/bucket/rotz.json
+++ b/bucket/rotz.json
@@ -25,19 +25,19 @@
             "64bit": {
                 "url": "https://github.com/volllly/rotz/releases/download/v$version/rotz-x86_64-pc-windows-msvc.zip",
                 "hash": {
-                    "url": "https://github.com/volllly/rotz/releases/download/v$version/rotz-x86_64-pc-windows-msvc.zip.sha256",
+                    "url": "https://github.com/volllly/rotz/releases/download/v$version/rotz-x86_64-pc-windows-msvc.zip.sha256"
                 }
             },
             "32bit": {
                 "url": "https://github.com/volllly/rotz/releases/download/v$version/rotz-i686-pc-windows-msvc.zip",
                 "hash": {
-                    "url": "https://github.com/volllly/rotz/releases/download/v$version/rotz-i686-pc-windows-msvc.zip.sha256",
+                    "url": "https://github.com/volllly/rotz/releases/download/v$version/rotz-i686-pc-windows-msvc.zip.sha256"
                 }
             },
             "arm64": {
                 "url": "https://github.com/volllly/rotz/releases/download/v$version/rotz-aarch64-pc-windows-msvc.zip",
                 "hash": {
-                    "url": "https://github.com/volllly/rotz/releases/download/v$version/rotz-aarch64-pc-windows-msvc.zip.sha256",
+                    "url": "https://github.com/volllly/rotz/releases/download/v$version/rotz-aarch64-pc-windows-msvc.zip.sha256"
                 }
             }
         }


### PR DESCRIPTION
The content of the `rotz.json` is not valid json. This was causing issues when installing `rotz` using `scoop`.

Thanks for the amazing tool! 😄